### PR TITLE
Require json to prevent missing method error

### DIFF
--- a/lib/puppet/provider/keystone_user/openstack.rb
+++ b/lib/puppet/provider/keystone_user/openstack.rb
@@ -1,5 +1,6 @@
 require 'net/http'
 require 'puppet/provider/keystone'
+require 'json'
 
 Puppet::Type.type(:keystone_user).provide(
   :openstack,


### PR DESCRIPTION
Using type `keystone_user` evaluated to the following error message:

```
Error: /Stage[main]/Keystone::Roles::Admin/Keystone_user[admin]: Could not evaluate: undefined method `to_json' for #<Hash:0x00000004e2d458>
```