### PR TITLE
Fix keystone_validate_service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -102,7 +102,7 @@ class keystone::service(
   }
 
   if $validate and $admin_token and $admin_endpoint {
-    $cmd = "openstack --os-auth-url ${admin_endpoint} --os-token ${admin_token} ${insecure_s} ${cacert_s} user list"
+    $cmd = "keystone --os-endpoint ${admin_endpoint}v2.0/ --os-token ${admin_token} ${insecure_s} ${cacert_s} user-list"
     $catch = 'name'
     exec { 'validate_keystone_connection':
       path        => '/usr/bin:/bin:/usr/sbin:/sbin',


### PR DESCRIPTION
python-openstackclient returns no resource found while keystone command works better.